### PR TITLE
Updated broken link with a new repository URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Your contributions and suggestions are heartily welcome. Please check the [Contr
 * [OSX Command Line Cheat Sheet](https://github.com/herrbischoff/awesome-osx-command-line)
 * [PowerShell Cheat Sheet](https://pen-testing.sans.org/blog/2016/05/25/sans-powershell-cheat-sheet) - SANS PowerShell Cheat Sheet from SEC560 Course [(PDF version)](docs/PowerShellCheatSheet_v41.pdf)
 * [Regexp Security Cheat Sheet](https://github.com/attackercan/regexp-security-cheatsheet)
-* [Security Cheat Sheets](https://github.com/jshaw87/Cheatsheets) - A collection of security cheat sheets
+* [Security Cheat Sheets](https://github.com/teamghsoftware/security-cheatsheets) - A collection of security cheat sheets
 * [Unix / Linux Cheat Sheet](http://cheatsheetworld.com/programming/unix-linux-cheat-sheet/)
 
 ## Discovery


### PR DESCRIPTION
In security cheat sheets there is https://github.com/jshaw87/Cheatsheets which doesn't exist. I replaced it with https://github.com/teamghsoftware/security-cheatsheets